### PR TITLE
Add provenance metadata updater tool

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3900,8 +3900,8 @@ packages:
   timestamp: 1765062031645
 - pypi: ./
   name: pytest-conda-solvers
-  version: 0.1.dev124
-  sha256: 401b62caa8acb7fc0b5d983967e6f32dad073344a33a9dfa268706fad3e96584
+  version: 0.1.dev133+dirty
+  sha256: d35702e98c9acb4bf758d0c51c14f8d38939a8afc438e7614e25ac32b79bdb94
   requires_dist:
   - conda
   - fastapi-cache2

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ pytest-conda-solvers = {path = ".", editable = true}
 generate-schema = "python -m pytest_conda_solvers.cli"
 test-classic-solver = "pytest --conda-solver=classic conda-solver-tests tests/test_provenance.py"
 test-libmamba-solver = "pytest --conda-solver=libmamba conda-solver-tests tests/test_provenance.py"
+update-provenance = "python tools/update_provenance.py"
 
 [workspace]
 authors = ["conda contributors"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires-python = ">=3.12"
 conda-solvers = "pytest_conda_solvers.plugin"
 
 [project.urls]
-Repository = "https://github.com/zklaus/pytest-conda-solvers"
+Repository = "https://github.com/conda-incubator/pytest-conda-solvers"
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -328,6 +328,8 @@ async def main() -> None:
             force=args.force,
             dry_run=args.dry_run,
         )
+        for r in file_results:
+            r["yaml_file"] = yaml_path.name
         all_results.extend(file_results)
         n_updated = sum(1 for r in file_results if r["status"] == "updated")
         n_unchanged = sum(1 for r in file_results if r["status"] == "unchanged")

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -340,6 +340,7 @@ async def main() -> None:
         )
 
     if args.json:
+        sys.stdout = _real_stdout
         print(json.dumps(all_results, indent=2))
 
 

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -166,10 +166,14 @@ def _update_yaml(
                     f"/{parts[0]}#L{start}-L{end}"
                 )
                 out.append(f"{indent}url: {new_url}\n")
+                old_m = URL_PATTERN.match(old_url)
+                old_start = int(old_m.group("start")) if old_m and old_m.group("start") else None
+                old_end = int(old_m.group("end")) if old_m and old_m.group("end") else None
+                status = "updated" if (old_start != start or old_end != end) else "unchanged"
                 results.append(
                     {
                         "node_id": current_node_id,
-                        "status": "updated",
+                        "status": status,
                         "old_url": old_url,
                         "new_url": new_url,
                     }
@@ -190,7 +194,7 @@ def _update_yaml(
 
         out.append(line)
 
-    if not dry_run and any(result["status"] == "updated" for result in results):
+    if not dry_run and any(result["status"] in ("updated", "unchanged") for result in results):
         yaml_path.write_text("".join(out), encoding="utf-8")
 
     return results
@@ -325,11 +329,17 @@ async def main() -> None:
             dry_run=args.dry_run,
         )
         all_results.extend(file_results)
-        n = sum(1 for result in file_results if result["status"] == "updated")
-        if n:
+        n_updated = sum(1 for r in file_results if r["status"] == "updated")
+        n_unchanged = sum(1 for r in file_results if r["status"] == "unchanged")
+        if n_updated or n_unchanged:
             action = "would update" if args.dry_run else "updated"
-            print(f"{action} {n} test(s) in {yaml_path.name}")
-            total += n
+            parts = []
+            if n_updated:
+                parts.append(f"{n_updated} shifted")
+            if n_unchanged:
+                parts.append(f"{n_unchanged} SHA-only")
+            print(f"{action} {n_updated + n_unchanged} test(s) in {yaml_path.name} ({', '.join(parts)})")
+            total += n_updated + n_unchanged
 
     print()
     print(f"{'Would update' if args.dry_run else 'Updated'} {total} test(s) total.")

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -20,6 +20,8 @@ import argparse
 import ast
 import functools
 import re
+import shutil
+import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -35,10 +37,28 @@ URL_PATTERN = re.compile(
 
 
 @functools.cache
+def _gh_token() -> str | None:
+    if shutil.which("gh") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, timeout=5
+        )
+        token = result.stdout.strip()
+        return token if token else None
+    except Exception:
+        return None
+
+
+@functools.cache
 def _fetch_source(commit: str, filepath: str) -> str:
     url = f"https://raw.githubusercontent.com/conda/conda/{commit}/{filepath}"
     print(f"  fetching {filepath} @ {commit[:12]}...")
-    with urllib.request.urlopen(url) as resp:
+    req = urllib.request.Request(url)
+    token = _gh_token()
+    if token:
+        req.add_header("Authorization", f"token {token}")
+    with urllib.request.urlopen(req) as resp:
         return resp.read().decode("utf-8")
 
 

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -18,13 +18,15 @@ Run from the repository root.
 
 import argparse
 import ast
+import asyncio
 import functools
 import re
 import shutil
 import subprocess
 import sys
-import urllib.request
 from pathlib import Path
+
+import httpx
 
 REPO_ROOT = Path(__file__).parent.parent
 YAML_DIR = REPO_ROOT / "conda-solver-tests"
@@ -35,9 +37,13 @@ URL_PATTERN = re.compile(
     r"(?:#L(?P<start>\d+)-L(?P<end>\d+))?$"
 )
 
+# Pre-populated by _fetch_all() before any parsing begins.
+_source_cache: dict[tuple[str, str], str] = {}
+
 
 @functools.cache
 def _gh_token() -> str | None:
+    """Return a GitHub token from `gh auth token`, or None if gh is unavailable."""
     if shutil.which("gh") is None:
         return None
     try:
@@ -50,16 +56,23 @@ def _gh_token() -> str | None:
         return None
 
 
-@functools.cache
+async def _fetch_all(pairs: set[tuple[str, str]], token: str | None) -> None:
+    """Fetch all (commit, filepath) pairs concurrently over a single HTTP/2 connection."""
+    headers = {"Authorization": f"token {token}"} if token else {}
+
+    async def _fetch_one(client: httpx.AsyncClient, commit: str, filepath: str) -> None:
+        url = f"https://raw.githubusercontent.com/conda/conda/{commit}/{filepath}"
+        print(f"  fetching {filepath} @ {commit[:12]}...")
+        resp = await client.get(url)
+        resp.raise_for_status()
+        _source_cache[commit, filepath] = resp.text
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        await asyncio.gather(*[_fetch_one(client, c, f) for c, f in pairs])
+
+
 def _fetch_source(commit: str, filepath: str) -> str:
-    url = f"https://raw.githubusercontent.com/conda/conda/{commit}/{filepath}"
-    print(f"  fetching {filepath} @ {commit[:12]}...")
-    req = urllib.request.Request(url)
-    token = _gh_token()
-    if token:
-        req.add_header("Authorization", f"token {token}")
-    with urllib.request.urlopen(req) as resp:
-        return resp.read().decode("utf-8")
+    return _source_cache[commit, filepath]
 
 
 @functools.cache
@@ -119,9 +132,7 @@ def _update_yaml(
         if nid_m:
             current_node_id = nid_m.group(2).strip()
 
-        url_m = re.match(
-            r"(\s+)url:\s+(https://github\.com/conda/conda/blob/.+)", line
-        )
+        url_m = re.match(r"(\s+)url:\s+(https://github\.com/conda/conda/blob/.+)", line)
         if url_m and current_node_id:
             indent = url_m.group(1)
             parts = current_node_id.split("::")
@@ -163,7 +174,7 @@ def _update_yaml(
     return updated
 
 
-def main() -> None:
+async def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--commit",
@@ -184,7 +195,9 @@ def main() -> None:
     args = parser.parse_args()
 
     if len(args.commit) != 40 or not re.fullmatch(r"[0-9a-f]+", args.commit):
-        sys.exit(f"error: --commit must be a full 40-character lowercase SHA, got {args.commit!r}")
+        sys.exit(
+            f"error: --commit must be a full 40-character lowercase SHA, got {args.commit!r}"
+        )
 
     print(f"Target commit: {args.commit}")
     if args.dry_run:
@@ -216,8 +229,22 @@ def main() -> None:
                 current_node_id = None
                 current_commit = None
 
-    # For each unique old commit, fetch both versions and compare
-    new_lines: dict[tuple[str, str], tuple[int, int]] = {}  # (filepath, func) -> (start, end)
+    # Collect all unique (commit, filepath) pairs and compare
+    pairs: set[tuple[str, str]] = set()
+    for old_commit, file_funcs in by_old_commit.items():
+        if old_commit == args.commit:
+            continue
+        for filepath in file_funcs:
+            pairs.add((old_commit, filepath))
+            pairs.add((args.commit, filepath))
+
+    if pairs:
+        await _fetch_all(pairs, _gh_token())
+        print()
+
+    new_lines: dict[
+        tuple[str, str], tuple[int, int]
+    ] = {}  # (filepath, func) -> (start, end)
     changed: set[tuple[str, str]] = set()  # AST changed between old and new
 
     for old_commit, file_funcs in by_old_commit.items():
@@ -231,7 +258,9 @@ def main() -> None:
             for func_name in sorted(funcs):
                 key = (filepath, func_name)
                 if func_name not in new_parsed:
-                    print(f"  MISSING  {func_name!r} not found in {filepath} at new commit")
+                    print(
+                        f"  MISSING  {func_name!r} not found in {filepath} at new commit"
+                    )
                     continue
                 start, end, new_node = new_parsed[func_name]
                 new_lines[key] = (start, end)
@@ -243,7 +272,9 @@ def main() -> None:
                     else:
                         print(f"  OK       {func_name!r} in {filepath}")
                 else:
-                    print(f"  NEW      {func_name!r} not found at old commit, will update")
+                    print(
+                        f"  NEW      {func_name!r} not found at old commit, will update"
+                    )
     print()
 
     # Apply updates
@@ -272,4 +303,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -25,6 +25,8 @@ import argparse
 import ast
 import asyncio
 import functools
+import json
+import os
 import re
 import shutil
 import subprocess
@@ -62,7 +64,7 @@ def _gh_token() -> str | None:
 
 
 async def _fetch_all(pairs: set[tuple[str, str]], token: str | None) -> None:
-    """Fetch all (commit, filepath) pairs concurrently over a single HTTP/2 connection."""
+    """Fetch all (commit, filepath) pairs concurrently."""
     headers = {"Authorization": f"token {token}"} if token else {}
 
     async def _fetch_one(client: httpx.AsyncClient, commit: str, filepath: str) -> None:
@@ -125,12 +127,12 @@ def _update_yaml(
     changed: set[tuple[str, str]],
     force: bool,
     dry_run: bool,
-) -> int:
-    """Patch a single YAML file. Returns number of tests updated."""
+) -> list[dict]:
+    """Patch a single YAML file. Returns one result dict per test encountered."""
     lines = yaml_path.read_text(encoding="utf-8").splitlines(keepends=True)
     out = []
     current_node_id: str | None = None
-    updated = 0
+    results: list[dict] = []
 
     for line in lines:
         nid_m = re.match(r"(\s+)node_id:\s+(.+)", line)
@@ -140,6 +142,7 @@ def _update_yaml(
         url_m = re.match(r"(\s+)url:\s+(https://github\.com/conda/conda/blob/.+)", line)
         if url_m and current_node_id:
             indent = url_m.group(1)
+            old_url = url_m.group(2).strip()
             parts = current_node_id.split("::")
             key = (parts[0], parts[1])
 
@@ -147,6 +150,13 @@ def _update_yaml(
                 print(
                     f"  SKIP  {current_node_id!r}: AST changed between commits "
                     f"(use --force to update anyway)"
+                )
+                results.append(
+                    {
+                        "node_id": current_node_id,
+                        "status": "skipped",
+                        "old_url": old_url,
+                    }
                 )
                 current_node_id = None
             elif key in new_lines:
@@ -156,7 +166,14 @@ def _update_yaml(
                     f"/{parts[0]}#L{start}-L{end}"
                 )
                 out.append(f"{indent}url: {new_url}\n")
-                updated += 1
+                results.append(
+                    {
+                        "node_id": current_node_id,
+                        "status": "updated",
+                        "old_url": old_url,
+                        "new_url": new_url,
+                    }
+                )
                 current_node_id = None
                 continue
 
@@ -173,10 +190,10 @@ def _update_yaml(
 
         out.append(line)
 
-    if not dry_run and updated:
+    if not dry_run and any(result["status"] == "updated" for result in results):
         yaml_path.write_text("".join(out), encoding="utf-8")
 
-    return updated
+    return results
 
 
 async def main() -> None:
@@ -197,12 +214,22 @@ async def main() -> None:
         action="store_true",
         help="Show what would change without writing files",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a JSON summary to stdout and suppress all other output. "
+        "Combine with --dry-run to preview what would change as JSON without writing files.",
+    )
     args = parser.parse_args()
 
     if len(args.commit) != 40 or not re.fullmatch(r"[0-9a-f]+", args.commit):
         sys.exit(
             f"error: --commit must be a full 40-character lowercase SHA, got {args.commit!r}"
         )
+
+    if args.json:
+        _real_stdout = sys.stdout
+        sys.stdout = open(os.devnull, "w")
 
     print(f"Target commit: {args.commit}")
     if args.dry_run:
@@ -251,6 +278,7 @@ async def main() -> None:
         tuple[str, str], tuple[int, int]
     ] = {}  # (filepath, func) -> (start, end)
     changed: set[tuple[str, str]] = set()  # AST changed between old and new
+    all_results: list[dict] = []
 
     for old_commit, file_funcs in by_old_commit.items():
         if old_commit == args.commit:
@@ -265,6 +293,9 @@ async def main() -> None:
                 if func_name not in new_parsed:
                     print(
                         f"  MISSING  {func_name!r} not found in {filepath} at new commit"
+                    )
+                    all_results.append(
+                        {"node_id": f"{filepath}::{func_name}", "status": "missing"}
                     )
                     continue
                 start, end, new_node = new_parsed[func_name]
@@ -285,7 +316,7 @@ async def main() -> None:
     # Apply updates
     total = 0
     for yaml_path in yaml_files:
-        n = _update_yaml(
+        file_results = _update_yaml(
             yaml_path,
             args.commit,
             new_lines,
@@ -293,6 +324,8 @@ async def main() -> None:
             force=args.force,
             dry_run=args.dry_run,
         )
+        all_results.extend(file_results)
+        n = sum(1 for result in file_results if result["status"] == "updated")
         if n:
             action = "would update" if args.dry_run else "updated"
             print(f"{action} {n} test(s) in {yaml_path.name}")
@@ -305,6 +338,9 @@ async def main() -> None:
             f"  {len(changed)} test(s) skipped due to AST changes. "
             f"Re-run with --force to update them anyway."
         )
+
+    if args.json:
+        print(json.dumps(all_results, indent=2))
 
 
 if __name__ == "__main__":

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -16,6 +16,11 @@ Usage:
 Run from the repository root.
 """
 
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx"]
+# ///
+
 import argparse
 import ast
 import asyncio

--- a/tools/update_provenance.py
+++ b/tools/update_provenance.py
@@ -1,0 +1,255 @@
+"""
+Update provenance metadata in conda-solver-tests/*.yaml to a new conda/conda commit.
+
+For each test, this tool:
+  1. Fetches the test function source at both the old (stored) commit and the
+     new (target) commit.
+  2. Compares the two ASTs structurally (ignoring line numbers and formatting).
+  3. If the ASTs are identical, updates `commit` and `url` (with fresh line
+     ranges) in the YAML file.
+  4. If the ASTs differ, it warns and skips the test -- the ported test may
+     need manual review. Use --force to update anyway.
+
+Usage:
+    python tools/update_provenance.py --commit <SHA> [--force] [--dry-run]
+
+Run from the repository root.
+"""
+
+import argparse
+import ast
+import functools
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+YAML_DIR = REPO_ROOT / "conda-solver-tests"
+
+URL_PATTERN = re.compile(
+    r"^https://github\.com/(?P<org>[^/]+)/(?P<repo>[^/]+)/blob/"
+    r"(?P<commit>[0-9a-f]+)/(?P<path>[^#]+)"
+    r"(?:#L(?P<start>\d+)-L(?P<end>\d+))?$"
+)
+
+
+@functools.cache
+def _fetch_source(commit: str, filepath: str) -> str:
+    url = f"https://raw.githubusercontent.com/conda/conda/{commit}/{filepath}"
+    print(f"  fetching {filepath} @ {commit[:12]}...")
+    with urllib.request.urlopen(url) as resp:
+        return resp.read().decode("utf-8")
+
+
+@functools.cache
+def _parse_functions(commit: str, filepath: str) -> dict[str, tuple[int, int, ast.AST]]:
+    """Return {qualified_name: (start_line, end_line, ast_node)} for all functions."""
+    source = _fetch_source(commit, filepath)
+    tree = ast.parse(source)
+    funcs: dict[str, tuple[int, int, ast.AST]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    funcs[f"{node.name}.{item.name}"] = (
+                        item.lineno,
+                        item.end_lineno,
+                        item,
+                    )
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            funcs[node.name] = (node.lineno, node.end_lineno, node)
+    return funcs
+
+
+def _ast_dump(node: ast.AST) -> str:
+    """Dump an AST node without position attributes for structural comparison."""
+    return ast.dump(node, include_attributes=False)
+
+
+def _collect_node_ids() -> dict[str, set[str]]:
+    """Return {filepath: {func_name, ...}} grouped from all YAML node_ids."""
+    file_funcs: dict[str, set[str]] = {}
+    for yaml_path in sorted(YAML_DIR.glob("*.yaml")):
+        for line in yaml_path.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"\s+node_id:\s+(.+)", line)
+            if m:
+                parts = m.group(1).strip().split("::")
+                filepath, func_name = parts[0], parts[1]
+                file_funcs.setdefault(filepath, set()).add(func_name)
+    return file_funcs
+
+
+def _update_yaml(
+    yaml_path: Path,
+    new_commit: str,
+    new_lines: dict[tuple[str, str], tuple[int, int]],
+    changed: set[tuple[str, str]],
+    force: bool,
+    dry_run: bool,
+) -> int:
+    """Patch a single YAML file. Returns number of tests updated."""
+    lines = yaml_path.read_text(encoding="utf-8").splitlines(keepends=True)
+    out = []
+    current_node_id: str | None = None
+    updated = 0
+
+    for line in lines:
+        nid_m = re.match(r"(\s+)node_id:\s+(.+)", line)
+        if nid_m:
+            current_node_id = nid_m.group(2).strip()
+
+        url_m = re.match(
+            r"(\s+)url:\s+(https://github\.com/conda/conda/blob/.+)", line
+        )
+        if url_m and current_node_id:
+            indent = url_m.group(1)
+            parts = current_node_id.split("::")
+            key = (parts[0], parts[1])
+
+            if key in changed and not force:
+                print(
+                    f"  SKIP  {current_node_id!r}: AST changed between commits "
+                    f"(use --force to update anyway)"
+                )
+                current_node_id = None
+            elif key in new_lines:
+                start, end = new_lines[key]
+                new_url = (
+                    f"https://github.com/conda/conda/blob/{new_commit}"
+                    f"/{parts[0]}#L{start}-L{end}"
+                )
+                out.append(f"{indent}url: {new_url}\n")
+                updated += 1
+                current_node_id = None
+                continue
+
+        # Also update commit: lines
+        commit_m = re.match(r"(\s+)commit:\s+([0-9a-f]{40})", line)
+        if commit_m and current_node_id:
+            # Only rewrite if we're going to update this test's url too
+            parts = current_node_id.split("::")
+            key = (parts[0], parts[1])
+            if key in new_lines and (key not in changed or force):
+                indent = commit_m.group(1)
+                out.append(f"{indent}commit: {new_commit}\n")
+                continue
+
+        out.append(line)
+
+    if not dry_run and updated:
+        yaml_path.write_text("".join(out), encoding="utf-8")
+
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit",
+        required=True,
+        metavar="SHA",
+        help="Target conda/conda commit SHA to update provenance to",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Update even if the function AST changed between commits",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without writing files",
+    )
+    args = parser.parse_args()
+
+    if len(args.commit) != 40 or not re.fullmatch(r"[0-9a-f]+", args.commit):
+        sys.exit(f"error: --commit must be a full 40-character lowercase SHA, got {args.commit!r}")
+
+    print(f"Target commit: {args.commit}")
+    if args.dry_run:
+        print("(dry run — no files will be written)")
+    print()
+
+    # Collect all (filepath, func_name) pairs referenced in YAMLs, grouped by
+    # the commit stored in each test's provenance block.
+    yaml_files = sorted(YAML_DIR.glob("*.yaml"))
+
+    # Build: {old_commit: {filepath: {func_name}}}
+    by_old_commit: dict[str, dict[str, set[str]]] = {}
+    for yaml_path in yaml_files:
+        current_node_id = None
+        current_commit = None
+        for line in yaml_path.read_text(encoding="utf-8").splitlines():
+            nid_m = re.match(r"\s+node_id:\s+(.+)", line)
+            if nid_m:
+                current_node_id = nid_m.group(1).strip()
+            commit_m = re.match(r"\s+commit:\s+([0-9a-f]{40})", line)
+            if commit_m:
+                current_commit = commit_m.group(1)
+            if current_node_id and current_commit:
+                parts = current_node_id.split("::")
+                filepath, func_name = parts[0], parts[1]
+                by_old_commit.setdefault(current_commit, {}).setdefault(
+                    filepath, set()
+                ).add(func_name)
+                current_node_id = None
+                current_commit = None
+
+    # For each unique old commit, fetch both versions and compare
+    new_lines: dict[tuple[str, str], tuple[int, int]] = {}  # (filepath, func) -> (start, end)
+    changed: set[tuple[str, str]] = set()  # AST changed between old and new
+
+    for old_commit, file_funcs in by_old_commit.items():
+        if old_commit == args.commit:
+            print(f"Commit {old_commit[:12]} already matches target, skipping.")
+            continue
+        print(f"Comparing {old_commit[:12]} -> {args.commit[:12]}:")
+        for filepath, funcs in file_funcs.items():
+            old_parsed = _parse_functions(old_commit, filepath)
+            new_parsed = _parse_functions(args.commit, filepath)
+            for func_name in sorted(funcs):
+                key = (filepath, func_name)
+                if func_name not in new_parsed:
+                    print(f"  MISSING  {func_name!r} not found in {filepath} at new commit")
+                    continue
+                start, end, new_node = new_parsed[func_name]
+                new_lines[key] = (start, end)
+                if func_name in old_parsed:
+                    _, _, old_node = old_parsed[func_name]
+                    if _ast_dump(old_node) != _ast_dump(new_node):
+                        changed.add(key)
+                        print(f"  CHANGED  {func_name!r} in {filepath}")
+                    else:
+                        print(f"  OK       {func_name!r} in {filepath}")
+                else:
+                    print(f"  NEW      {func_name!r} not found at old commit, will update")
+    print()
+
+    # Apply updates
+    total = 0
+    for yaml_path in yaml_files:
+        n = _update_yaml(
+            yaml_path,
+            args.commit,
+            new_lines,
+            changed,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
+        if n:
+            action = "would update" if args.dry_run else "updated"
+            print(f"{action} {n} test(s) in {yaml_path.name}")
+            total += n
+
+    print()
+    print(f"{'Would update' if args.dry_run else 'Updated'} {total} test(s) total.")
+    if changed and not args.force:
+        print(
+            f"  {len(changed)} test(s) skipped due to AST changes. "
+            f"Re-run with --force to update them anyway."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Based on discussions with @jaimergp, this PR adds a script to update provenance metadata for ported tests. See https://github.com/conda-incubator/pytest-conda-solvers/issues/26#issuecomment-4182841646. Notes:
- It still updates/pins all tests to one commit/revision right now, which should be fine.
- This code is generated with GPT-5 mini due to their 0x token usage promotion in VS Code chat (also serves as AI disclosure from my end!)
