### PR TITLE
Delete condarc files that are no longer used in CI

### DIFF
--- a/.github/condarc-conda-forge
+++ b/.github/condarc-conda-forge
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-anaconda_anon_usage: false

--- a/.github/condarc-defaults
+++ b/.github/condarc-defaults
@@ -1,3 +1,0 @@
-channels:
-  - defaults
-anaconda_anon_usage: false


### PR DESCRIPTION
As title. I had a chat with @zklaus, and he told me that he added them in https://github.com/conda-incubator/pytest-conda-solvers/commit/9642ab0abb05f4de3e0b41426f3ff1a845b11415. They are no longer used and the test infrastructure has changed quite a bit by then, so I propose that we delete them – we can always bring this setup back if we need it.