### PR TITLE
Add Zizmor workflow to our CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: v0.65.0
           cache: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: "pedantic"
+          advanced-security: "false" # needed for annotations to be true
+          annotations: "true" # mutually exclusive with sarif output


### PR DESCRIPTION
Adds a workflow to run Zizmor. I've already fully fixed all findings in previous PRs, so it's just a rubber stamp on our existing setup. This is the recommended way to integrate Zizmor into a repository as per the official docs: https://docs.zizmor.sh/integrations/#github-actions. The reason is mostly that running it in GHA CI allows us to not be encumbered by things like GitHub rate limits. Another benefit is that it provides annotations on code that has violations (limited to 10 by GitHub, but still pretty useful).

Also updates the pixi action to v0.9.5 while we're at it.