### PR TITLE
Accept both `node_id` separator forms in the upstream-tests collector

### DIFF
--- a/tools/collect_ported_node_ids.py
+++ b/tools/collect_ported_node_ids.py
@@ -70,8 +70,10 @@ def _map_node_id(node_id: str) -> list[str]:
     node_id = _SUB_INDEX.sub("", node_id)
     file, _, rest = node_id.partition("::")
     if file == SOLVER_HELPERS_FILE:
-        # such as SolverTests.test_iopro_mkl --> test_iopro_mkl
-        method = rest.split(".", 1)[1]
+        # The class/method separator appears in both accepted provenance forms,
+        # SolverTests.test_iopro_mkl and SolverTests::test_iopro_mkl (see
+        # tools/update_provenance.py), so split on either.
+        method = re.split(r"::|\.", rest, maxsplit=1)[1]
         return [f"{SOLVER_TESTS_FILE}::{cls}::{method}" for cls in SOLVER_TESTS_CLASSES]
     return [node_id]
 


### PR DESCRIPTION
I noticed that the side-by-side job from #49 crashes with an `IndexError` on the stacked PRs from #53 and later. This is because the collector only handles the `SolverTests.test_x` provenance form, but the YAML files also use `SolverTests::test_x` (both of these are valid per tools/update_provenance.py). This PR makes us split on either separator.
